### PR TITLE
Fixing .gitignore to include IntelliJ project files as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,11 @@ local.properties
 #################
 
 out/
-.idea/
+.idea/*
+!.idea/.name
+!.idea/modules.xml
+!.idea/encodings.xml
+!.idea/vcs.xml
 *.eml
 
 # External tool builders

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+mocos-controlator

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false">
+    <file url="PROJECT" charset="ISO-8859-1" />
+  </component>
+</project>
+

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/mocos-controlator.iml" filepath="$PROJECT_DIR$/mocos-controlator.iml" />
+    </modules>
+  </component>
+</project>
+

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>
+


### PR DESCRIPTION
Exactly as title. Also have not included those files that change randomly by the IDE like workspace.xml (that apparently saves the windows states). We will be able to create a more complex module structure without worrying about repeating the configuration on all computers.
