### PR TITLE
Disabling swipe for the SubjectCard

### DIFF
--- a/src/com/marcioapf/mocos/view/SubjectCard.java
+++ b/src/com/marcioapf/mocos/view/SubjectCard.java
@@ -26,11 +26,14 @@ import com.nineoldandroids.util.IntProperty;
 
 public class SubjectCard extends LinearLayout {
 
-    private static boolean block_delete_subject = false;
+    // to enable swiping to delete subjects, just set this flag to false
+    private static final boolean DISABLE_SWIPE = true;
+
+    private static boolean block_delete_subject = DISABLE_SWIPE;
     private static Runnable reset_block_delete_flag = new Runnable() {
         @Override
         public void run() {
-            block_delete_subject = false;
+            block_delete_subject = DISABLE_SWIPE;
         }
     };
 


### PR DESCRIPTION
Addressing feedback from the new version of the app, now disabling the
swipe functionality for the subject cards to avoid accidental deleting. It
can be easily enabled again, and intructions to do so have been inserted
on comments.
